### PR TITLE
Refactor breadcrumb and route names to use 'index' instead of 'all' for consistency and clarity in the sabhero-blog application. This change improves the semantic meaning of the routes and breadcrumbs.

### DIFF
--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -50,32 +50,32 @@ Breadcrumbs::for('sabhero-blog.post.metro.show', static function (BreadcrumbTrai
     ]));
 });
 
-Breadcrumbs::for('sabhero-blog.category.all', static function (BreadcrumbTrail $trail) {
+Breadcrumbs::for('sabhero-blog.category.index', static function (BreadcrumbTrail $trail) {
     $trail->parent('home');
-    $trail->push('Categories', route('sabhero-blog.category.all'));
+    $trail->push('Categories', route('sabhero-blog.category.index'));
 });
 
 Breadcrumbs::for('sabhero-blog.category.post', static function (BreadcrumbTrail $trail, $category) {
-    $trail->parent('sabhero-blog.category.all');
+    $trail->parent('sabhero-blog.category.index');
     $trail->push($category->name, route('sabhero-blog.category.post', $category->slug));
 });
 
 Breadcrumbs::for('sabhero-blog.tag.post', static function (BreadcrumbTrail $trail, $tag) {
-    $trail->parent('sabhero-blog.tag.all');
+    $trail->parent('sabhero-blog.tag.index');
     $trail->push($tag->name, route('sabhero-blog.tag.post', $tag->slug));
 });
 
-Breadcrumbs::for('sabhero-blog.tag.all', static function (BreadcrumbTrail $trail) {
+Breadcrumbs::for('sabhero-blog.tag.index', static function (BreadcrumbTrail $trail) {
     $trail->parent('home');
-    $trail->push('Tags', route('sabhero-blog.tag.all'));
+    $trail->push('Tags', route('sabhero-blog.tag.index'));
 });
 
-Breadcrumbs::for('sabhero-blog.author.all', static function (BreadcrumbTrail $trail) {
+Breadcrumbs::for('sabhero-blog.author.index', static function (BreadcrumbTrail $trail) {
     $trail->parent('home');
-    $trail->push('Authors', route('sabhero-blog.author.all'));
+    $trail->push('Authors', route('sabhero-blog.author.index'));
 });
 
 Breadcrumbs::for('sabhero-blog.author.show', static function (BreadcrumbTrail $trail, $author) {
-    $trail->parent('sabhero-blog.author.all');
+    $trail->parent('sabhero-blog.author.index');
     $trail->push($author->name, route('sabhero-blog.author.show', $author->slug));
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,11 +14,11 @@ Route::middleware(config('sabhero-blog.route.middleware'))
         Route::get('/search', [PostController::class, 'search'])
             ->name('sabhero-blog.post.search');
         Route::get('/tags', [TagController::class, 'allTags'])
-            ->name('sabhero-blog.tag.all');
+            ->name('sabhero-blog.tag.index');
         Route::get('/categories', [CategoryController::class, 'allCategories'])
-            ->name('sabhero-blog.category.all');
+            ->name('sabhero-blog.category.index');
         Route::get('/authors', [AuthorController::class, 'allAuthors'])
-            ->name('sabhero-blog.author.all');
+            ->name('sabhero-blog.author.index');
         Route::get('/authors/{author:slug}', [AuthorController::class, 'posts'])
             ->name('sabhero-blog.author.show');
         Route::feeds();


### PR DESCRIPTION
Refactors the breadcrumb and route names in the sabhero-blog application, changing all instances of 'all' to 'index'. This adjustment enhances consistency and clarity throughout the codebase.

The motivation behind this change is to improve the semantic meaning of our routes and breadcrumbs. The term 'index' is more aligned with RESTful conventions, indicating a listing of resources, while 'all' can be ambiguous. By adopting 'index', we create a clearer understanding for developers and users alike, making the application's navigation more intuitive.

This refactor not only streamlines our code but also contributes to better readability and maintainability moving forward. Overall, these changes will enhance both the developer experience and the user interface of the sabhero-blog application.