### PR TITLE
Remove unused configuration for dropdown in the blog settings and eliminate the canAccessPanel method from the User model to streamline the codebase.

### DIFF
--- a/config/sabhero-blog.php
+++ b/config/sabhero-blog.php
@@ -24,9 +24,6 @@ return [
     'heading_permalink' => [
         'html_class' => 'scroll-mt-40',
     ],
-    'dropdown' => [
-        'name' => 'Posts',
-    ],
     'crm' => [
         'name' => 'CRM',
         'link' => '#',

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -4,7 +4,6 @@ namespace Fuelviews\SabHeroBlog\Models;
 
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasAvatar;
-use Filament\Panel;
 use Fuelviews\SabHeroBlog\Traits\HasBlog;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -200,17 +200,4 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasMedia
                 $q->where('status', 'published');
             });
     }
-
-    public function canAccessPanel(Panel $panel): bool
-    {
-        $allowedDomains = config('sabhero-blog.user.allowed_domains', []);
-
-        foreach ($allowedDomains as $domain) {
-            if (str_ends_with($this->email, $domain)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }


### PR DESCRIPTION
Streamlines the codebase by removing unused configurations and methods that are no longer necessary. Specifically, it eliminates the dropdown configuration from the blog settings and removes the `canAccessPanel` method from the User model.

### Changes:
1. **Removed Dropdown Configuration**: Deleted the unused 'dropdown' section from `config/sabhero-blog.php`.
2. **Eliminated Method**: Removed the `canAccessPanel` method from the `User` model in `src/Models/User.php`.